### PR TITLE
Bypass Worker for prerendered static routes

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,19 +15,32 @@
     "directory": ".output/public",
     "binding": "ASSETS",
     "run_worker_first": [
-      "/*",
-      "!/_nuxt/*",
-      "!/browse-index/*",
-      "!/favicon.*",
-      "!/*.svg",
-      "!/*.png",
-      "!/*.jpg",
-      "!/*.jpeg",
-      "!/*.webp",
-      "!/*.woff2",
-      "!/*.css",
-      "!/*.js",
-      "!/*.json"
+      // Keep prerendered routes asset-first so Cloudflare can serve the built
+      // HTML directly instead of paying a Worker invocation for every request.
+      "/api/*",
+      "/browse",
+      "/browse/*",
+      "/search",
+      "/word/*",
+      "/en/browse",
+      "/en/browse/*",
+      "/en/search",
+      "/en/word/*",
+      "/yue-Hans/browse",
+      "/yue-Hans/browse/*",
+      "/yue-Hans/search",
+      "/yue-Hans/word/*",
+      "/zh-Hant/browse",
+      "/zh-Hant/browse/*",
+      "/zh-Hant/search",
+      "/zh-Hant/word/*",
+      "/zh-Hans/browse",
+      "/zh-Hans/browse/*",
+      "/zh-Hans/search",
+      "/zh-Hans/word/*",
+      "/robots.txt",
+      "/sitemap.xml",
+      "/sitemaps/*"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- narrow Cloudflare `assets.run_worker_first` to the app's actual dynamic routes
- let prerendered home/about pages be served directly from static assets instead of always hitting the Worker
- keep search, word, browse, API, robots, and sitemap routes on the Worker path

## Testing
- `npm run build`
- `node --test tests/route-paths.test.mjs`

## Preview validation
- use the PR preview deployment to repeat-load `/`, `/about`, localized home/about routes, `/search?q=嗌&show=results`, `/word/星球人`, and `/browse`
- prerendered routes should stop appearing in Worker logs; dynamic routes should still appear

## Follow-up before prod
- add/verify the Cloudflare edge redirect for `www -> apex` so static routes keep canonical-host behavior after bypassing the Worker